### PR TITLE
chore(workspace): broaden CI branch validation

### DIFF
--- a/.agents/skills/shared/cross-repo-change/workflow.md
+++ b/.agents/skills/shared/cross-repo-change/workflow.md
@@ -17,9 +17,10 @@ clearly created them.
 ## Branching
 
 - Use one branch slug across all affected repos.
-- Prefer `feat/<short-topic>` for features, `fix/<short-topic>` for defects,
-  `docs/<short-topic>` for documentation-only work, and `chore/<short-topic>`
-  for harness or maintenance changes.
+- Prefer descriptive `feat/<short-topic>` for features, `fix/<short-topic>` for
+  defects, `docs/<short-topic>` for documentation-only work, and
+  `chore/<short-topic>` for harness or maintenance changes.
+- Avoid agent/tool-specific branch prefixes.
 - Do not branch untouched repos.
 - Use `./scripts/workspace/branch.mjs <branch-slug> <repo...>` for matching branches.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, "feat/*", "feature/*" ]
+    branches: ["**"]
   pull_request:
     branches: [ main ]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,9 @@ local validation and handoff rules.
   repository checkouts, and `./scripts/workspace/bootstrap.mjs` to clone them.
 - Use `./scripts/workspace/doctor.mjs` when checking whether a developer or
   agent workspace is ready for multi-repo work.
-- Use one shared branch slug across all affected child repositories.
+- Use one shared branch slug across all affected child repositories. Prefer
+  descriptive `feat/`, `fix/`, `docs/`, or `chore/` branch slugs, and avoid
+  agent/tool-specific prefixes.
 - Use Conventional Commits for every commit subject and pull request title.
 - Prefer a central tracking issue for work that touches multiple repositories.
 - Use `./scripts/workspace/status.mjs` before and after multi-repo work.

--- a/scripts/harness/check-agent-harness.sh
+++ b/scripts/harness/check-agent-harness.sh
@@ -168,6 +168,7 @@ expect_contains "docs/agent-harness/agent-handoff-policy.md" "exact commands run
 expect_contains "docs/agent-harness/harness-adoption-guide.md" "Repo-local harness"
 expect_contains "docs/agent-harness/harness-adoption-guide.md" "Workspace harness"
 expect_contains "docs/agent-harness/DEVELOPMENT.md" "Documentation Drift Control"
+expect_contains ".github/workflows/ci.yml" 'branches: ["**"]'
 expect_contains "docs/developer-getting-started.md" "task setup"
 expect_contains "docs/developer-getting-started.md" "System Architecture"
 expect_contains "docs/developer-getting-started.md" "Agent-Assisted Development"
@@ -184,6 +185,7 @@ expect_contains ".agents/skills/shared/contract-change/SKILL.md" "docs/contracts
 expect_contains ".agents/skills/shared/workspace-maintenance/SKILL.md" "workspace.yaml"
 expect_contains ".agents/skills/shared/testing-validation/SKILL.md" "handoff evidence"
 expect_contains ".agents/skills/shared/cross-repo-change/SKILL.md" "merge order"
+expect_contains ".agents/skills/shared/cross-repo-change/workflow.md" "Avoid agent/tool-specific branch prefixes."
 expect_contains ".agents/skills/shared/open-pr/SKILL.md" "draft PR"
 expect_contains ".agents/skills/shared/open-pr/workflow.md" "check-conventional-commits.mjs"
 expect_contains "scripts/sync/shared-skills.sh" "--dry-run"


### PR DESCRIPTION
## Summary
- Run root CI on all branch pushes instead of only `main`, `feat/*`, and `feature/*`.
- Clarify workspace branch guidance to prefer descriptive type-based branch slugs and avoid agent/tool-specific prefixes.
- Extend the agent harness check so the CI branch coverage and branch guidance do not drift.

## Cross-Repo Change Set
Tracking issue: None

Related PRs:
- None

Merge order:
1. acornops-workspace

## Validation
- `./scripts/harness/check-agent-harness.sh` passed
- `node scripts/harness/check-conventional-commits.mjs --message "chore(workspace): broaden CI branch validation"` passed
- `node scripts/harness/check-conventional-commits.mjs --last 1` passed
- `node scripts/harness/check-platform-harness.mjs` passed
- `node scripts/harness/check-platform-contracts.mjs` passed
- `./scripts/sync/shared-skills.sh --dry-run` passed; reported expected child-repo sync targets only
- `./scripts/workspace/status.mjs` inspected workspace and child repo status

## Docs Impact
- Updated `AGENTS.md` and the shared cross-repo workflow branch guidance.

## Residual Risk
- CI branch coverage is broader, so more branch pushes will run the root harness workflow.