### PR TITLE
chore: rename workspace repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
-# AcornOps Workspace Agent Entry Point
+# AcornOps Repository Agent Entry Point
 
-Use this file as the map for cross-repository work in the AcornOps workspace.
+Use this file as the map for cross-repository work from the canonical AcornOps
+repository and its local workspace.
 Durable repository-specific knowledge belongs in each child repository.
 
 ## Start Here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to AcornOps
+
+AcornOps is developed across independently versioned repositories. Clone this
+repository and bootstrap the complete workspace before making a change that
+spans components:
+
+```bash
+git clone https://github.com/acornops/acornops.git
+cd acornops
+task setup
+```
+
+Read [AGENTS.md](AGENTS.md), the
+[developer getting-started guide](docs/developer-getting-started.md), and the
+affected child repository's `README.md` and `AGENTS.md` before editing.
+
+Use the validation command declared for the affected repository in
+[`workspace.yaml`](workspace.yaml). Cross-repository changes should use one
+shared branch slug, record a change set under `change-sets/`, and link related
+pull requests with their intended merge order.
+
+Commit subjects and pull request titles follow
+[Conventional Commits](docs/agent-harness/conventional-commits.md).
+
+For documentation-only contributions, see the
+[public docs contribution guide](https://github.com/acornops/docs-website/blob/main/CONTRIBUTING.md).
+
+Do not open a public issue for a suspected vulnerability. Follow the
+[security policy](SECURITY.md) instead.

--- a/README.md
+++ b/README.md
@@ -2,23 +2,78 @@
   <img width="220" src="https://raw.githubusercontent.com/acornops/docs-website/main/logo/light.svg" alt="AcornOps" />
 </p>
 
-<h1 align="center">AcornOps Workspace</h1>
+<h1 align="center">AcornOps</h1>
 
 <p align="center">
-  <a href="https://github.com/acornops/acornops-workspace/actions/workflows/ci.yml"><img src="https://github.com/acornops/acornops-workspace/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <img src="https://img.shields.io/badge/workspace-harness-blue.svg" alt="Workspace harness" />
+  <a href="https://github.com/acornops/acornops/actions/workflows/ci.yml"><img src="https://github.com/acornops/acornops/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <img src="https://img.shields.io/badge/contracts-checked-blue.svg" alt="Contracts checked" />
   <img src="https://img.shields.io/badge/commits-conventional-green.svg" alt="Conventional commits" />
 </p>
 
 <p align="center">
-  Versioned workspace harness for AcornOps multi-repository development.
+  Open-source, self-hosted AI-assisted operations for Kubernetes clusters and Linux/systemd VMs.
 </p>
 
-This repository is the developer entry point for working across AcornOps
-repositories. It owns the workspace manifest, setup helpers, shared skills,
-shared GitHub templates, and cross-repository documentation. It does not own
-product source code. Product repositories are checked out as ignored child
+<p align="center">
+  <a href="https://console.demo.acornops.dev/"><strong>Try the live demo</strong></a>
+  ·
+  <a href="https://docs.acornops.dev/quickstart">Self-host AcornOps</a>
+  ·
+  <a href="https://docs.acornops.dev/">Read the docs</a>
+  ·
+  <a href="https://docs.acornops.dev/integrations">Build an integration</a>
+</p>
+
+> [!IMPORTANT]
+> AcornOps is under active experimental development. APIs, deployment
+> contracts, and upgrade paths may change before a stable release.
+
+AcornOps connects a central operations platform to Kubernetes clusters and
+Linux/systemd VMs through outbound target agents. Operators can inspect live
+target context, run guided investigations, coordinate controlled remediation,
+and automate repeatable operational work from one management console.
+
+The platform keeps operators in control:
+
+- AgentK and AgentV initiate outbound connections to the control plane.
+- Linux/systemd built-in tools are read-only.
+- Kubernetes writes require explicit RBAC, agent enablement, run permission,
+  and tool access.
+- Write confirmation is required by default and pauses a run before the
+  specific write-capable tool call.
+- The LLM gateway enforces run-scoped model and tool access, runtime limits,
+  and budgets.
+- Remote MCP servers are target-scoped and discovery-first; discovered tools
+  stay disabled until reviewed and enabled.
+
+Start with the [public demo](https://console.demo.acornops.dev/), follow the
+[quickstart](https://docs.acornops.dev/quickstart), or review the
+[system architecture](docs/system-architecture.md).
+
+## Repository Map
+
+AcornOps is split into independently versioned components with explicit
+contracts between them.
+
+| Repository | Responsibility |
+| --- | --- |
+| [`management-console`](https://github.com/acornops/management-console) | Browser experience for workspaces, targets, runs, Agents, Workflows, approvals, and tools |
+| [`control-plane`](https://github.com/acornops/control-plane) | Authentication, workspace APIs, target registration, run state, webhooks, and agent coordination |
+| [`execution-engine`](https://github.com/acornops/execution-engine) | Durable run execution, streaming events, retries, cancellation, and tool coordination |
+| [`llm-gateway`](https://github.com/acornops/llm-gateway) | Model-provider routing, MCP brokering, secrets, and policy enforcement |
+| [`agentk`](https://github.com/acornops/agentk) | Outbound Kubernetes discovery, snapshots, logs, and controlled tool execution |
+| [`agentv`](https://github.com/acornops/agentv) | Outbound Linux/systemd snapshots, logs, and read-only built-in tools |
+| [`acornops-deployment`](https://github.com/acornops/acornops-deployment) | Docker Compose and Kubernetes deployment tracks, compatibility metadata, and runbooks |
+| [`charts`](https://github.com/acornops/charts) | Public Helm repository mirror for packaged platform and agent charts |
+| [`docs-website`](https://github.com/acornops/docs-website) | Public operator, deployment, integration, architecture, and API documentation |
+
+## Develop AcornOps
+
+This repository is also the developer entry point for working across the
+independently versioned AcornOps repositories. It owns the workspace manifest,
+setup helpers, shared skills, shared GitHub templates, and cross-repository
+documentation. Product repositories are checked out as ignored child
 directories and remain independently versioned.
 
 ## Workspace Model
@@ -105,7 +160,7 @@ stage or commit product repository contents from the workspace repo.
 Clone the workspace:
 
 ```bash
-git clone https://github.com/acornops/acornops-workspace.git acornops
+git clone https://github.com/acornops/acornops.git
 cd acornops
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+AcornOps is under active experimental development. Security reports are
+accepted for the current default branch and active development branches
+maintained by the AcornOps team.
+
+## Reporting a Vulnerability
+
+Do not open a public GitHub issue for a suspected vulnerability.
+
+Report security issues through the AcornOps Discord:
+
+https://discord.gg/KHUUdXfsXv
+
+Include the affected repositories, components, versions or commit SHAs, impact,
+reproduction steps, and relevant logs or screenshots. Do not include live
+secrets, tokens, private keys, or customer data.
+
+## Disclosure
+
+Give the maintainers time to acknowledge, investigate, and remediate a valid
+report before public disclosure. Maintainers may follow up through Discord for
+reproduction details, mitigation guidance, and coordinated disclosure timing.

--- a/docs/developer-getting-started.md
+++ b/docs/developer-getting-started.md
@@ -7,7 +7,7 @@ to repo-local commands without turning product repositories into submodules.
 ## First-Time Setup
 
 ```bash
-git clone https://github.com/acornops/acornops-workspace.git acornops
+git clone https://github.com/acornops/acornops.git
 cd acornops
 task setup
 ```

--- a/scripts/harness/check-platform-harness.mjs
+++ b/scripts/harness/check-platform-harness.mjs
@@ -197,7 +197,7 @@ function checkStandardRepo(repo) {
   expect(agents.split('\n').length <= 140, `${repoRelative(repo, 'AGENTS.md')} should remain short`);
   expect(!agents.includes('/Users/'), `${repoRelative(repo, 'AGENTS.md')} should use portable relative links`);
   expect(agents.includes('Agent-Assisted Development'), `${repoRelative(repo, 'AGENTS.md')} should describe agent-assisted development entrypoints`);
-  expect(agents.includes('acornops-workspace'), `${repoRelative(repo, 'AGENTS.md')} should point cross-repo agent work to the workspace root`);
+  expect(agents.includes('`acornops` repository'), `${repoRelative(repo, 'AGENTS.md')} should point cross-repo agent work to the canonical repository`);
   expect(!agents.includes('acornops-agent-standards'), `${repoRelative(repo, 'AGENTS.md')} must not reference the retired standards repository`);
   expect(agents.includes('.agents/skills/shared'), `${repoRelative(repo, 'AGENTS.md')} should describe shared skills`);
   expect(agents.includes('.agents/skills/local'), `${repoRelative(repo, 'AGENTS.md')} should describe local skills`);
@@ -226,14 +226,14 @@ function checkDocsSiteRepo(repo) {
   expect(agents.split('\n').length <= 140, `${repoRelative(repo, 'AGENTS.md')} should remain short`);
   expect(!agents.includes('/Users/'), `${repoRelative(repo, 'AGENTS.md')} should use portable relative links`);
   expect(agents.includes('Agent-Assisted Development'), `${repoRelative(repo, 'AGENTS.md')} should describe agent-assisted development entrypoints`);
-  expect(agents.includes('acornops-workspace'), `${repoRelative(repo, 'AGENTS.md')} should point cross-repo agent work to the workspace root`);
+  expect(agents.includes('`acornops` repository'), `${repoRelative(repo, 'AGENTS.md')} should point cross-repo agent work to the canonical repository`);
   expect(agents.includes('.agents/skills/shared'), `${repoRelative(repo, 'AGENTS.md')} should describe shared skills`);
   expect(agents.includes('.agents/skills/local'), `${repoRelative(repo, 'AGENTS.md')} should describe local skills`);
   expect(agents.includes('exact commands run'), `${repoRelative(repo, 'AGENTS.md')} should include handoff evidence`);
   expect(agents.includes('Conventional Commits'), `${repoRelative(repo, 'AGENTS.md')} should include commit policy`);
   expect(agents.includes('Vendor Neutrality'), `${repoRelative(repo, 'AGENTS.md')} should include vendor-neutrality policy`);
   expect(readme.includes('Agent-Assisted Development'), `${repoRelative(repo, 'README.md')} should describe agent-assisted development entrypoints`);
-  expect(contributing.includes('AcornOps workspace repository'), `${repoRelative(repo, 'CONTRIBUTING.md')} should point cross-repo work to the workspace`);
+  expect(contributing.includes('canonical AcornOps repository'), `${repoRelative(repo, 'CONTRIBUTING.md')} should point cross-repo work to the canonical repository`);
   expect(packageJson.scripts?.check === 'node scripts/check-docs.mjs', `${repoRelative(repo, 'package.json')} should expose docs structural checks`);
   expect(Boolean(packageJson.scripts?.validate), `${repoRelative(repo, 'package.json')} should expose docs validation`);
   expect(Boolean(packageJson.scripts?.links), `${repoRelative(repo, 'package.json')} should expose link validation`);
@@ -253,7 +253,7 @@ function checkStaticInfrastructureRepo(repo) {
   expect(agents.split('\n').length <= 140, `${repoRelative(repo, 'AGENTS.md')} should remain short`);
   expect(!agents.includes('/Users/'), `${repoRelative(repo, 'AGENTS.md')} should use portable relative links`);
   expect(agents.includes('Agent-Assisted Development'), `${repoRelative(repo, 'AGENTS.md')} should describe agent-assisted development entrypoints`);
-  expect(agents.includes('acornops-workspace'), `${repoRelative(repo, 'AGENTS.md')} should point cross-repo agent work to the workspace root`);
+  expect(agents.includes('`acornops` repository'), `${repoRelative(repo, 'AGENTS.md')} should point cross-repo agent work to the canonical repository`);
   expect(agents.includes('.agents/skills/shared'), `${repoRelative(repo, 'AGENTS.md')} should describe shared skills`);
   expect(agents.includes('.agents/skills/local'), `${repoRelative(repo, 'AGENTS.md')} should describe local skills`);
   expect(readme.includes('helm repo add acornops'), `${repoRelative(repo, 'README.md')} should document the Helm repository install path`);

--- a/scripts/harness/check-sync-drift.mjs
+++ b/scripts/harness/check-sync-drift.mjs
@@ -154,7 +154,7 @@ function checkGitHooksSetup(repos) {
   const expectedHooksPath = path.join(workspaceRoot, '.githooks');
 
   if (configuredHooksPath(workspaceRoot) !== expectedHooksPath) {
-    failures.push('acornops-workspace: core.hooksPath is not configured');
+    failures.push('acornops: core.hooksPath is not configured');
   }
 
   for (const repo of repos) {

--- a/scripts/harness/pre-commit-validate.mjs
+++ b/scripts/harness/pre-commit-validate.mjs
@@ -49,7 +49,7 @@ function checkAgentsLineLimit(repoName, repoPath) {
 
 const repoRoot = gitOutput(['rev-parse', '--show-toplevel']);
 const repo = repoRoot === workspaceRoot
-  ? { name: 'acornops-workspace', absolutePath: workspaceRoot }
+  ? { name: 'acornops', absolutePath: workspaceRoot }
   : loadWorkspace().find((candidate) => candidate.absolutePath === repoRoot);
 
 if (!repo) {

--- a/scripts/harness/pre-push-validate.mjs
+++ b/scripts/harness/pre-push-validate.mjs
@@ -37,13 +37,13 @@ function runTaskChecks(repoName, repoPath) {
 }
 
 function runWorkspaceHarness() {
-  run('./scripts/harness/check-agent-harness.sh', workspaceRoot, 'acornops-workspace');
-  run('node scripts/harness/check-platform-harness.mjs', workspaceRoot, 'acornops-workspace');
+  run('./scripts/harness/check-agent-harness.sh', workspaceRoot, 'acornops');
+  run('node scripts/harness/check-platform-harness.mjs', workspaceRoot, 'acornops');
 }
 
 const repoRoot = gitOutput(['rev-parse', '--show-toplevel']);
 const repo = repoRoot === workspaceRoot
-  ? { name: 'acornops-workspace', absolutePath: workspaceRoot }
+  ? { name: 'acornops', absolutePath: workspaceRoot }
   : loadWorkspace().find((candidate) => candidate.absolutePath === repoRoot);
 
 if (!repo) {

--- a/scripts/sync/githooks.sh
+++ b/scripts/sync/githooks.sh
@@ -138,7 +138,7 @@ if [[ "${DRY_RUN}" == true ]]; then
   echo "Dry run: no Git config will be written"
 fi
 
-configure_hooks_path "acornops-workspace" "${WORKSPACE_ROOT}"
+configure_hooks_path "acornops" "${WORKSPACE_ROOT}"
 
 for i in "${!REPO_NAMES[@]}"; do
   repo_name="${REPO_NAMES[$i]}"

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -1,6 +1,6 @@
 workspace:
   name: acornops
-  description: Versioned AcornOps multi-repository workspace harness.
+  description: Canonical multi-repository development workspace for AcornOps.
 
 repositories:
   - name: acornops-deployment


### PR DESCRIPTION
## Summary

- reframe the renamed `acornops` repository as the public project and contributor entry point
- add a product-first README, repository map, contributor guide, and security policy
- update clone instructions, workspace metadata, and harness labels for the canonical name

## Validation

- `task validate` — passed
- pre-commit and pre-push harness checks — passed
- stale-reference audit — no public `acornops-workspace` references remain

## Coordination

- acornops/acornops-deployment#13
- acornops/control-plane#12
- acornops/docs-website#8
- acornops/execution-engine#4
- acornops/agentk#1
- acornops/agentv#1
- acornops/llm-gateway#4
- acornops/management-console#15
- acornops/charts#1

The initial organization profile is published directly to `acornops/.github` because that repository was previously empty.

## Rename note

The GitHub repository has already been renamed from `acornops/acornops-workspace` to `acornops/acornops`. GitHub preserves old web and Git URLs through redirects; the old repository name must not be reused.
