### PR TITLE
chore(workspace): register platform admin console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,11 @@
 /execution-engine/
 /agentk/
 /agentv/
+/k8s-agent/
+/vm-agent/
 /llm-gateway/
 /management-console/
+/platform-admin-console/
 /charts/
 
 # Local review and planning artifacts.

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ acornops/
   control-plane/  # ignored child repo for the control plane API
   docs-website/  # ignored child repo for public Mintlify docs
   execution-engine/  # ignored child repo for run execution
-  agentk/  # ignored child repo for workload-cluster agents
-  agentv/  # ignored child repo for Linux/systemd AgentV work
+  k8s-agent/  # ignored child repo for the Kubernetes AgentK runtime
+  vm-agent/  # ignored child repo for Linux/systemd AgentV work
   llm-gateway/  # ignored child repo for model and MCP brokering
   management-console/  # ignored child repo for the browser console
+  platform-admin-console/  # ignored child repo for platform governance
   charts/  # ignored child repo for the public Helm chart repository
 ```
 

--- a/docs/agent-harness/repository-capability-summary.md
+++ b/docs/agent-harness/repository-capability-summary.md
@@ -53,6 +53,16 @@ Canonical Validation: `npm run validate`
 Deployment Model: Docker multi-stage build with Nginx runtime, local Vite dev mode via compose override
 Infrastructure Tools: Docker Compose, Nginx, Vite
 
+## Repository: platform-admin-console
+Purpose: Governance-only platform administration UI and BFF for workspace identity, existing workspace access, plan assignment, lifecycle state, and platform-admin audit without tenant operational-data access.
+Primary Language: JavaScript
+Framework: Node.js built-in HTTP server + browser-native HTML/CSS/JavaScript
+Build Command: `npm run build`
+Test Command: `npm test`
+Canonical Validation: `npm run validate`
+Deployment Model: Dedicated `admin.acornops.dev` service with a server-held control-plane admin credential and same-origin browser API
+Infrastructure Tools: Node.js, control-plane `/admin/v1`, CSP, endpoint allowlisting
+
 ## Repository: agentk
 Purpose: Cluster-resident outbound-only Kubernetes agent for telemetry snapshots and JSON-RPC tool execution.
 Primary Language: TypeScript

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -21,7 +21,9 @@ repository's `ARCHITECTURE.md`; deployment mechanics live in
 ```mermaid
 flowchart LR
     User[Operator Browser]
+    PlatformAdmin[Platform Administrator Browser]
     Console[Management Console]
+    AdminConsole[Platform Admin Console + BFF]
     CP[Control Plane]
     CPDB[(Control Plane Postgres)]
     CPRedis[(Control Plane Redis)]
@@ -39,6 +41,9 @@ flowchart LR
 
     User --> Console
     Console -->|/api/v1| CP
+    PlatformAdmin -->|admin.acornops.dev| AdminConsole
+    PlatformAdmin -->|OIDC login + opaque admin session| CP
+    AdminConsole -->|governance-only /admin/v1 allowlist| CP
     User --> OIDC
     OIDC --> CP
 
@@ -68,6 +73,15 @@ The management console is the operator-facing browser application. It talks to
 the control plane through `/api/v1` and depends on the control plane for
 authentication state, workspace and target APIs, run orchestration, and
 agent-backed operations.
+
+The platform admin console is a separate governance application and
+server-side BFF. It talks only to an explicit allowlist of `/admin/v1`
+control-plane endpoints for workspace identity, existing workspace access,
+plans, lifecycle state, and platform administration audit. It does not expose workspace
+logs, targets, runs, tools, workspace audit, impersonation, or workload-control
+operations. Its browser never receives the control-plane admin bearer token;
+production authorization requires both that BFF credential and a dedicated
+OIDC-authenticated human session with one of three fixed platform roles.
 
 The control plane is the public application boundary. It owns authenticated
 HTTP APIs, session handling, workspace state, target registration, run state,
@@ -183,6 +197,7 @@ remains closed.
 Production public route hostnames:
 
 - `console.acornops.dev/` serves the management console.
+- `admin.acornops.dev/` serves the platform admin console.
 - `api.acornops.dev/api` serves the control plane API and agent WebSocket route.
 - `console.acornops.dev/api` remains available for same-origin browser session flows.
 - `docs.acornops.dev/` serves the public documentation site.
@@ -198,6 +213,8 @@ Internal-only services:
 ## Repository Ownership
 
 - `management-console`: browser UI and nginx production image.
+- `platform-admin-console`: platform-governance UI and admin API BFF with a
+  deny-by-default `/admin/v1` endpoint allowlist.
 - `control-plane`: auth, workspaces, sessions, run state, agent
   bridge, and orchestration API.
 - `execution-engine`: run worker and durable execution callbacks.

--- a/scripts/harness/check-platform-contracts.mjs
+++ b/scripts/harness/check-platform-contracts.mjs
@@ -23,10 +23,11 @@ function stable(value) {
 const manifests = {
   'control-plane': readJson('control-plane/docs/contracts/manifest.json'),
   'management-console': readJson('management-console/docs/contracts/manifest.json'),
+  'platform-admin-console': readJson('platform-admin-console/docs/contracts/manifest.json'),
   'execution-engine': readJson('execution-engine/docs/contracts/manifest.json'),
   'llm-gateway': readJson('llm-gateway/docs/contracts/manifest.json'),
-  'agentk': readJson('agentk/docs/contracts/manifest.json'),
-  'agentv': readJson('agentv/docs/contracts/manifest.json')
+  'agentk': readJson('k8s-agent/docs/contracts/manifest.json'),
+  'agentv': readJson('vm-agent/docs/contracts/manifest.json')
 };
 
 const failures = [];
@@ -57,6 +58,7 @@ for (const [repoName, manifest] of Object.entries(manifests)) {
 }
 
 expectCounterpart('control-plane', 'management-console', 'management-console', 'control-plane');
+expectCounterpart('control-plane', 'platform-admin-console', 'platform-admin-console', 'control-plane');
 expectCounterpart('control-plane', 'execution-engine', 'execution-engine', 'control-plane');
 expectCounterpart('control-plane', 'llm-gateway', 'llm-gateway', 'control-plane');
 expectCounterpart('control-plane', 'agentk', 'agentk', 'control-plane');

--- a/scripts/harness/check-platform-harness.mjs
+++ b/scripts/harness/check-platform-harness.mjs
@@ -203,13 +203,42 @@ function checkStandardRepo(repo) {
   expect(agents.includes('.agents/skills/local'), `${repoRelative(repo, 'AGENTS.md')} should describe local skills`);
   expect(agents.includes('docs/AGENT_HANDOFF.md'), `${repoRelative(repo, 'AGENTS.md')} should link agent handoff policy`);
   expect(readme.includes('Agent-Assisted Development'), `${repoRelative(repo, 'README.md')} should describe agent-assisted development entrypoints`);
-  expect(docsIndex.includes('docs/AGENT_HANDOFF.md'), `${repoRelative(repo, 'docs/index.md')} should link agent handoff policy`);
+  expect(docsIndex.includes('AGENT_HANDOFF.md'), `${repoRelative(repo, 'docs/index.md')} should link agent handoff policy`);
   expect(handoff.includes('Use Conventional Commits 1.0.0'), `${repoRelative(repo, 'docs/AGENT_HANDOFF.md')} should require commit policy`);
   expect(handoff.includes('exact commands run'), `${repoRelative(repo, 'docs/AGENT_HANDOFF.md')} should include handoff evidence`);
   expect(handoff.includes('Vendor Neutrality'), `${repoRelative(repo, 'docs/AGENT_HANDOFF.md')} should include vendor-neutrality policy`);
-  expect(docsIndex.includes('docs/QUALITY_SCORE.md'), `${repoRelative(repo, 'docs/index.md')} should link quality score`);
-  expect(docsIndex.includes('docs/RELIABILITY.md'), `${repoRelative(repo, 'docs/index.md')} should link reliability doc`);
-  expect(docsIndex.includes('docs/SECURITY.md'), `${repoRelative(repo, 'docs/index.md')} should link security doc`);
+  expect(docsIndex.includes('QUALITY_SCORE.md'), `${repoRelative(repo, 'docs/index.md')} should link quality score`);
+  expect(docsIndex.includes('RELIABILITY.md'), `${repoRelative(repo, 'docs/index.md')} should link reliability doc`);
+  expect(docsIndex.includes('SECURITY.md'), `${repoRelative(repo, 'docs/index.md')} should link security doc`);
+}
+
+function checkPlatformAdminRequirements(repo) {
+  for (const file of [
+    'docs/product-specs/current-requirements.md',
+    'docs/product-specs/requirements-baseline.json',
+    'scripts/check-requirements.mjs',
+    '.agents/skills/local/platform-admin-change/SKILL.md'
+  ]) {
+    expectRepoFile(repo, file);
+  }
+
+  const requirements = readRepo(repo, 'docs/product-specs/current-requirements.md');
+  const baseline = JSON.parse(readRepo(repo, 'docs/product-specs/requirements-baseline.json'));
+  const packageJson = JSON.parse(readRepo(repo, 'package.json'));
+  const skill = readRepo(repo, '.agents/skills/local/platform-admin-change/SKILL.md');
+  for (const marker of ['## Authority And Change Protocol', 'historical evidence, not current requirements', '## Superseded And Excluded Behavior', '## Contract-Blocked Capabilities']) {
+    expect(requirements.includes(marker), `${repoRelative(repo, 'docs/product-specs/current-requirements.md')} is missing ${marker}`);
+  }
+  expect(baseline.authority === 'docs/product-specs/current-requirements.md', `${repo.name} executable requirements authority must be repo-local`);
+  expect(baseline.expectedRuntime?.adminRouteCount === 15, `${repo.name} requirements must lock the current 15-route subset`);
+  expect(baseline.expectedRuntime?.allowedScopeCount === 7, `${repo.name} requirements must lock the current 7-scope subset`);
+  expect(baseline.required?.length >= 10 && baseline.excluded?.length >= 10 && baseline.blocked?.length >= 4, `${repo.name} requirements coverage is incomplete`);
+  expect(packageJson.scripts?.['requirements:check'] === 'node scripts/check-requirements.mjs', `${repo.name} must expose requirements:check`);
+  expect(packageJson.scripts?.validate?.includes('npm run requirements:check'), `${repo.name} validate must run requirements:check`);
+  expect(packageJson.scripts?.['validate:ci']?.includes('npm run requirements:check'), `${repo.name} validate:ci must run requirements:check`);
+  for (const marker of ['name: platform-admin-change', 'Classify the request', 'EXC-*', 'BLOCK-*', 'npm run requirements:check']) {
+    expect(skill.includes(marker), `${repo.name} local change skill is missing ${marker}`);
+  }
 }
 
 function checkDocsSiteRepo(repo) {
@@ -270,6 +299,7 @@ for (const repo of loadWorkspace()) {
     checkStaticInfrastructureRepo(repo);
   } else {
     checkStandardRepo(repo);
+    if (repo.name === 'platform-admin-console') checkPlatformAdminRequirements(repo);
   }
 }
 

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -28,14 +28,14 @@ repositories:
     validate: task validate
 
   - name: agentk
-    path: ./agentk
-    remote: https://github.com/acornops/agentk.git
+    path: ./k8s-agent
+    remote: https://github.com/acornops/k8s-agent.git
     default_branch: main
     validate: npm run validate
 
   - name: agentv
-    path: ./agentv
-    remote: https://github.com/acornops/agentv.git
+    path: ./vm-agent
+    remote: https://github.com/acornops/vm-agent.git
     default_branch: main
     validate: npm run validate
 
@@ -48,6 +48,12 @@ repositories:
   - name: management-console
     path: ./management-console
     remote: https://github.com/acornops/management-console.git
+    default_branch: main
+    validate: npm run validate
+
+  - name: platform-admin-console
+    path: ./platform-admin-console
+    remote: https://github.com/acornops/platform-admin-console.git
     default_branch: main
     validate: npm run validate
 


### PR DESCRIPTION
## Summary
- Register `platform-admin-console` as an AcornOps child repository.
- Extend workspace architecture, capability documentation, harness adoption, and cross-repository contract validation for the governance console.
- Preserve current Workflow V2 workspace policy and canonical repository paths.

## Cross-Repo Change Set
Related PRs:
- control plane: https://github.com/acornops/control-plane/pull/14
- platform admin console: https://github.com/acornops/platform-admin-console/pull/1
- deployment: https://github.com/acornops/acornops-deployment/pull/15
- workspace: this PR

Merge order:
1. control plane
2. platform admin console
3. deployment
4. workspace

## Validation
- `task validate` passed on the current PR head in GitHub Actions.
- The platform contract harness, runtime-truth check, and integrated workspace validation passed.
- `git diff --check` passed in every affected repository.

## Docs Impact
- Updated workspace topology, system architecture, repository capability summary, README, and harness enforcement.

## Residual Risk
- Keep the deployment admin API and console toggles disabled until matching images and staging prerequisites are ready.
